### PR TITLE
Add health check endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,10 @@ curl -F "file=@/path/till/ljud.wav" \
 
 Svaret är JSON som innehåller transkriptets segment, sammanhängande text och SRT-format. Alla formulärparametrar (t.ex. `model`, `chunk_length`, `assign_strategy`, `do_diarize` m.fl.) stöds även i API:t.
 
+### Health check
+- `GET /health` – returns `"OK"` for the web interface.
+- `GET /api/health` – returns JSON `{ "status": "ok" }`.
+
 ## Tips
 - For long files consider running behind a reverse proxy and using a queue/background job system.
 - Set `do_diarize` to `False` if you do not have a Hugging Face token.

--- a/app.py
+++ b/app.py
@@ -7,7 +7,7 @@ import tempfile
 from pathlib import Path
 from typing import Optional, Tuple, List
 
-from flask import Flask, request, render_template, redirect, url_for, flash, send_file, after_this_request, jsonify
+from flask import Flask, request, render_template, redirect, url_for, flash, send_file, after_this_request, jsonify, Response
 from werkzeug.utils import secure_filename
 from dotenv import load_dotenv
 import math
@@ -49,6 +49,16 @@ def _segments_to_srt(segments) -> str:
 @app.route("/")
 def index():
     return render_template("index.html")
+
+@app.route("/health")
+def health() -> tuple[str, int]:
+    """Simple health check for the web app."""
+    return "OK", 200
+
+@app.route("/api/health")
+def api_health() -> tuple[Response, int]:
+    """JSON health check for API clients."""
+    return jsonify({"status": "ok"}), 200
 
 @app.route("/transcribe", methods=["POST"])
 def transcribe_route():


### PR DESCRIPTION
## Summary
- add `/health` route for web health checks
- add `/api/health` JSON route for API clients
- document health endpoints in README

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_689ff94e8ec8832d91d9c0b18da705d3