### PR TITLE
Add unit tests and CI workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,22 @@
+name: Tests
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+      - name: Run tests
+        run: pytest

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 .env
+__pycache__/
+*.pyc

--- a/tests/test_audio_utils.py
+++ b/tests/test_audio_utils.py
@@ -1,0 +1,38 @@
+import sys
+from pathlib import Path
+
+import numpy as np
+import pytest
+import soundfile as sf
+
+sys.path.append(str(Path(__file__).resolve().parent.parent))
+
+from services.audio_utils import (
+    _parse_ffmpeg_duration,
+    _parse_ffmpeg_time,
+    _is_exact_16k_mono_wav_pcm,
+)
+
+
+def test_parse_ffmpeg_duration():
+    line = "Duration: 00:01:23.45, start: 0.000000, bitrate: 128 kb/s"
+    assert _parse_ffmpeg_duration(line) == pytest.approx(83.45)
+
+
+def test_parse_ffmpeg_time():
+    line = "size=       0kB time=00:00:10.50 bitrate=   0.0kbits/s"
+    assert _parse_ffmpeg_time(line) == pytest.approx(10.50)
+
+
+def test_is_exact_16k_mono_wav_pcm_true(tmp_path):
+    data = np.zeros(16000, dtype=np.float32)
+    file_path = tmp_path / "mono16k.wav"
+    sf.write(file_path, data, 16000, subtype="PCM_16")
+    assert _is_exact_16k_mono_wav_pcm(file_path) is True
+
+
+def test_is_exact_16k_mono_wav_pcm_false(tmp_path):
+    data = np.zeros(8000, dtype=np.float32)
+    file_path = tmp_path / "mono8k.wav"
+    sf.write(file_path, data, 8000, subtype="PCM_16")
+    assert _is_exact_16k_mono_wav_pcm(file_path) is False

--- a/tests/test_stt.py
+++ b/tests/test_stt.py
@@ -1,0 +1,46 @@
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parent.parent))
+
+from services import stt
+
+
+def _patch_torch(monkeypatch, available):
+    fake_torch = types.SimpleNamespace(
+        cuda=types.SimpleNamespace(is_available=lambda: available)
+    )
+
+    def fake_lazy_imports():
+        monkeypatch.setitem(sys.modules, "torch", fake_torch)
+        stt.torch = fake_torch
+
+    monkeypatch.setattr(stt, "_lazy_imports", fake_lazy_imports)
+
+
+def test_pick_device_prefers_cuda(monkeypatch):
+    _patch_torch(monkeypatch, available=True)
+    device, compute = stt._pick_device_and_compute(None, None)
+    assert device == "cuda"
+    assert compute == "float16"
+
+
+def test_pick_device_user_overrides(monkeypatch):
+    _patch_torch(monkeypatch, available=True)
+    device, compute = stt._pick_device_and_compute("cpu", None)
+    assert device == "cpu"
+    assert compute == "float32"
+
+    device, compute = stt._pick_device_and_compute(None, "int8")
+    assert device == "cuda"
+    assert compute == "int8"
+
+
+def test_pick_device_no_cuda(monkeypatch):
+    _patch_torch(monkeypatch, available=False)
+    device, compute = stt._pick_device_and_compute(None, None)
+    assert device == "cpu"
+    assert compute == "float32"


### PR DESCRIPTION
## Summary
- add tests for ffmpeg parsing and audio validation utilities
- add tests for device selection logic in STT module
- set up GitHub Actions workflow running pytest
- ignore Python cache files

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689ffed9c6dc832db713e952572d6bf7