### PR TITLE
Return JSON from health endpoint for Render

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ curl -F "file=@/path/till/ljud.wav" \
 Svaret är JSON som innehåller transkriptets segment, sammanhängande text och SRT-format. Alla formulärparametrar (t.ex. `model`, `chunk_length`, `assign_strategy`, `do_diarize` m.fl.) stöds även i API:t.
 
 ### Health check
-- `GET /health` – returns `"OK"` for the web interface.
+- `GET /health` – returns JSON `{ "status": "ok" }` for the web interface and Render.
 - `GET /api/health` – returns JSON `{ "status": "ok" }`.
 
 ## Tips

--- a/app.py
+++ b/app.py
@@ -51,9 +51,9 @@ def index():
     return render_template("index.html")
 
 @app.route("/health")
-def health() -> tuple[str, int]:
-    """Simple health check for the web app."""
-    return "OK", 200
+def health() -> tuple[Response, int]:
+    """Simple health check for the web app and Render."""
+    return jsonify({"status": "ok"}), 200
 
 @app.route("/api/health")
 def api_health() -> tuple[Response, int]:


### PR DESCRIPTION
## Summary
- Return JSON `{ "status": "ok" }` from `/health` for Render compatibility
- Document health check behavior in README

## Testing
- `python -m py_compile app.py`
- `python - <<'PY'
from app import app
client = app.test_client()
resp = client.get('/health')
print(resp.status_code, resp.json)
PY`

------
https://chatgpt.com/codex/tasks/task_e_68a001a8e2d0832d95932fef3f7e7b9d